### PR TITLE
fix: misstype in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To suggest an improvement or fix, open an issue (please check if a similar issue
 To build fonts, use the provided build script:
 
 ```
-cd ./source
+cd ./sources
 bash build.sh
 ```
 


### PR DESCRIPTION
The build guide specifies "source" as a directory to cd into on build. This should be "sources" as no "source" directory is present in the repository root.